### PR TITLE
limit permalink unique check to when changed

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ActiveRecord::Base
 
   validates_presence_of :email
   validates_uniqueness_of :email, allow_blank: true, if: :email_changed?, message: I18n.t('activerecord.errors.models.user.attributes.email.taken')
-  validates_uniqueness_of :permalink, allow_nil: true
+  validates_uniqueness_of :permalink, allow_nil: true, if: :permalink_changed?
   validates_format_of :email, with: Devise.email_regexp, allow_blank: true, if: :email_changed?
 
   validates_presence_of :password, if: :password_required?


### PR DESCRIPTION
This allows us to work around the fact that some imported farmers have nil values for permalinks, so that the records can still be valid and other changes can be made successfully.